### PR TITLE
 index.html: optionally handle backend-JSON instead of prerendered HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,67 @@
       }
     }
 
+    function progress_bar(percent) {
+      return '<div class="progress">' +
+               '<div class="progress-bar progress-bar-striped" ' +
+                    'role="progressbar" ' +
+                    'aria-valuenow="' + percent + '" ' +
+                    'aria-valuemin="0" aria-valuemax="100" ' +
+                    'style="width:' + percent + '%">' + percent + '%' +
+               '</div>' +
+             '</div>';
+    }
+
+    function pr_status(status) {
+      var divider = "";
+      var stat_html = "";
+      var failed_jobs_html = "";
+      var percent = 0;
+      var text = null;
+      var eta = "";
+
+      if (status.total && status.passed && status.failed &&
+          (status.total >= (status.passed + status.failed))) {
+        var done = status.passed + status.failed;
+        percent = Math.round((done * 100) / status.total);
+        text = glyphicon("stats") +
+          ' fail: ' + status.failed +
+          ' pass: ' + status.passed +
+          ' done: ' + done + '/' + status.total;
+        eta = glyphicon("time") + ' ' + status.eta;
+      }
+      else if (status.status) {
+        text = glyphicon("transfer") + ' ' + status.status;
+      }
+
+      if (text) {
+        stat_html += bs_row(bs_col(progress_bar(percent), 6) +
+                            bs_col(text, 4) +
+                            bs_col(eta, 2));
+      }
+      if (status.failed_jobs) {
+        if (status.failed_jobs.length > 0) {
+          failed_jobs_html += "<h5><strong>Failed jobs:</strong></h5>";
+        }
+        var gridsize = 4;
+        var row_content = "";
+        for (var i = 0; i < status.failed_jobs.length; i++) {
+          var failed_job = status.failed_jobs[i];
+          if ((i % gridsize) == gridsize) {
+            failed_jobs_html += bs_row(row_content);
+            row_content = "";
+          }
+          if (failed_job.href) {
+            failed_job.name = '<a href="' + failed_job.href + '"> ' +
+              failed_job.name + ' </a>';
+          }
+          row_content += bs_col(failed_job.name, Math.floor(12 / gridsize));
+        }
+        failed_jobs_html += bs_row(row_content);
+      }
+      return bs_col(divider + stat_html + failed_jobs_html, 12);
+    }
+
     function add_item(obj, type, pr) {
         var pattern = new RegExp("[0-9]+$")
         var prnum = pattern.exec(pr.url);
@@ -113,7 +174,12 @@
                 }
                 runtime_icon = "hourglass";
                 duration = moment.duration(pr.runtime * -1000).humanize();
-                status_html = pr.status_html;
+                if (pr.status_html) {
+                  status_html = pr.status_html;
+                }
+                else if (pr.status) {
+                  status_html = pr_status(pr.status);
+                }
                 break;
             default:
                 icon = "question-sign"
@@ -173,6 +239,24 @@
       });
     }
 
+    function update_status(event) {
+      var msg = JSON.parse(event.data);
+      if (msg.cmd == "reload_prs") {
+        get_prs();
+      }
+      else if (msg.cmd == "prstatus") {
+        var prnum = msg.prnum;
+        var html;
+        if (msg.html) {
+          html = msg.html;
+        }
+        else if (msg.status) {
+          html = pr_status(msg.status);
+        }
+        $('#pr-' + prnum + '-status').html(html);
+      }
+    }
+
   function connect_status() {
       // setup websocket with callbacks
       var ws = new WebSocket('wss://ci.riot-os.org/devel/status');
@@ -182,16 +266,7 @@
       ws.onclose = function() {
         setTimeout(connect_status, 1000);
       };
-      ws.onmessage = function(event) {
-          msg = JSON.parse(event.data);
-          if (msg.cmd == "reload_prs") {
-              get_prs();
-          }
-          else if (msg.cmd == "prstatus") {
-              prnum = msg.prnum
-              document.getElementById('pr-' + prnum + '-status').innerHTML = msg.html;
-          }
-      };
+      ws.onmessage = update_status;
     }
 
     function update_durations() {

--- a/index.html
+++ b/index.html
@@ -35,13 +35,51 @@
 -->
     </div>
     <script>
-    function add_icon(icon_name) {
-	if (icon_name)
-		return "<span class=\"glyphicon glyphicon-" + icon_name + "\" aria-hidden=\"true\"></span> "
-	else
-		return ""
-	}
+    function id_attr(id) {
+      if (id) {
+        return ' id="' + id + '"';
+      }
+      else {
+        return "";
+      }
+    }
 
+    function extraclasses_append(extraclasses) {
+      if (extraclasses && (extraclasses.length > 0)) {
+        return " " + extraclasses.join(" ");
+      }
+      return "";
+    }
+
+    function bs_row(content, id, extraclasses) {
+      return '<div' + id_attr(id) + ' class="row' +
+        extraclasses_append(extraclasses) + '">' + content + '</div>';
+    }
+
+    function bs_col(content, width, extraclasses) {
+      return '<div class="col-md-' + width +
+        extraclasses_append(extraclasses) + '">' + content + "</div>";
+    }
+
+    function bs_panel(title, body, id, extraclasses) {
+      return '<div' + id_attr(id) + ' class="panel' +
+        extraclasses_append(extraclasses) + '">' +
+                     '<div class="panel-heading">' +
+                       '<h3 class="panel-title">' + title + '</h3>' +
+                     '</div>' +
+                     '<div class="panel-body">' + body + '</div>' +
+                   "</div>"
+    }
+
+    function glyphicon(icon_name) {
+      if (icon_name) {
+        return "<span class=\"glyphicon glyphicon-" + icon_name +
+               "\"aria-hidden=\"true\"></span>";
+      }
+      else {
+        return "";
+      }
+    }
 
     function add_item(obj, type, pr) {
         var pattern = new RegExp("[0-9]+$")
@@ -88,38 +126,23 @@
         else {
             title = pr.title;
         }
-        obj.append("<div id=\"pr-" + prnum + "\" class=\"panel panel-" + cl + "\">" +
-                     "<div class=\"panel-heading\">" +
-                       "<h3 class=\"panel-title\">" +
-                         "<span class=\"glyphicon glyphicon-" + icon + "\" aria-hidden=\"true\"></span> " + title +
-                       "</h3>" +
-                     "</div>" +
-                     "<div class=\"panel-body\">" +
-                           "<div class=\"row\">" +
-                           "<div class=\"col-md-2\">" +
-                             "<span class=\"glyphicon glyphicon-user\" aria-hidden=\"true\"></span> " + pr.user +
-                           "</div>" +
-                           "<div class=\"col-md-2\">" +
-                             "<span class=\"glyphicon glyphicon-link\" aria-hidden=\"true\"></span> " +
-                             "<a href=\"" + pr.url + "\" target=\"_blank\">PR #" + prnum + "</a>" +
-                           "</div>" +
-                           "<div class=\"col-md-2\">" +
-                             "<span class=\"glyphicon glyphicon-tag\" aria-hidden=\"true\"></span> " +
-                             "<a href=\"https://github.com/RIOT-OS/RIOT/commit/" + pr.commit + "\" target=\"_blank\">" +
-                               "<code>" + pr.commit.substring(0,7) + "</code>" +
-                             "</a>" +
-                           "</div>" +
-                           "<div class=\"col-md-4\">" +
-                             "<span class=\"glyphicon glyphicon-calendar\" aria-hidden=\"true\"></span> " +
-                             d.toLocaleString() + " <div class=\"since\" style=\"display: inline\" since=\"" + (pr.since * 1000) + "\">()</div>" +
-                           "</div>" +
-                           "<div class=\"col-md-2\">" +
-                             add_icon(runtime_icon) + duration +
-                           "</div>" +
-                           "</div>" +
-                           "<div class=\"row\" id=\"pr-" + prnum + "-status\">" + status_html +"</div>" +
-                     "</div>" +
-                   "</div>");
+        obj.append(bs_panel(glyphicon(icon) + " " + title,
+                   bs_row(bs_col(glyphicon("user") + " " + pr.user, 2) +
+                          bs_col(glyphicon("link") +
+                            ' <a href="' + pr.url + '" target="_blank">' +
+                            'PR #' + prnum + '</a>', 2) +
+                          bs_col(glyphicon("tag") +
+                            ' <a href="https://github.com/RIOT-OS/RIOT/commit/' +
+                            pr.commit + '" target="_blank">' +
+                            "<code>" + pr.commit.substring(0,7) +
+                            "</code></a>", 2) +
+                          bs_col(glyphicon("calendar") + " " +
+                            d.toLocaleString() + ' <div ' +
+                            'class="since" style="display: inline"' +
+                            'since="' + (pr.since * 1000) + '">()</div>', 4) +
+                          bs_col(glyphicon(runtime_icon) + " " + duration, 2)) +
+                   bs_row(status_html, "pr-" + prnum + "-status"),
+                   "pr-" + prnum, ["panel-" + cl]));
     }
 
     function get_prs() {

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
         var row_content = "";
         for (var i = 0; i < status.failed_jobs.length; i++) {
           var failed_job = status.failed_jobs[i];
-          if ((i % gridsize) == gridsize) {
+          if ((i > 0) && ((i % gridsize) == 0)) {
             failed_jobs_html += bs_row(row_content);
             row_content = "";
           }

--- a/index.html
+++ b/index.html
@@ -93,6 +93,22 @@
     }
 
     function pr_status(status) {
+      /* the status parameter is expected to be an object with the following
+       * attributes:
+       *  - total (optional): total number of jobs to execute for the PR
+       *  - passed (optional): total number of jobs already done and passed
+       *    for the PR
+       *  - failed (optional): total number of jobs already done and failed
+       *    for the PR
+       *  - eta (required, when total, passed, and failed are provided,
+       *    otherwise optional): current ETA for the processing of the PR
+       *  - status (optional): a status text for the PR
+       *  - failed_jobs (optional): list of jobs (may be of length 0) that are
+       *    already done and failed. An object in this list is expected to have
+       *    the following attributes:
+       *      - name (required): the name of the job
+       *      - href (optional): a link to the logfile of the job
+       */
       var divider = "";
       var stat_html = "";
       var failed_jobs_html = "";


### PR DESCRIPTION
This allows us to separate frontend from backend. Currently bootstrap-specific HTML is generated within Murdock's scripts which is less then ideal if you want to keep the frontend portable. When murdock is ported to emit these JSON objects instead of HTML we can remove the HTML part.

Depends on ~~#2~~ (merged) and #3 

See https://github.com/RIOT-OS/murdock-scripts/pull/18 for how to provide the JSON objects server-side.