### PR TITLE
Revert "index.html: fix config include"

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css" integrity="sha384-fLW2N01lMqjakBkx3l/M9EahuwpSfeNvV63J5ezn3uZzapT0u7EYsXMjQV+0En5r" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
-    <script src="js/murdock-config.js.in"></script>
+    <script src="js/murdock-config.js"></script>
     <script src="js/moment.js"></script>
     <title>Murdock &mdash; Pull Requests: RIOT-OS/RIOT</title>
   </head>


### PR DESCRIPTION
Reverts RIOT-OS/murdock-html#8

Name difference "fixed" by #8 was intentional.