### PR TITLE
murdock-html: break job names on overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css" integrity="sha384-fLW2N01lMqjakBkx3l/M9EahuwpSfeNvV63J5ezn3uZzapT0u7EYsXMjQV+0En5r" crossorigin="anonymous">
     <script src="js/murdock-config.js"></script>
     <script src="js/moment.js"></script>
+    <style>
+      .pr-status-job {
+        word-wrap: break-word;
+      }
+    </style>
     <title>Murdock &mdash; Pull Requests: RIOT-OS/RIOT</title>
   </head>
   <body style="padding-top: 70px;">

--- a/js/murdock.js
+++ b/js/murdock.js
@@ -140,7 +140,8 @@ function pr_status(status) {
         failed_job.name = '<a href="' + failed_job.href + '"> ' +
           failed_job.name + ' </a>';
       }
-      row_content += bs_col(failed_job.name, Math.floor(12 / gridsize));
+      row_content += bs_col(failed_job.name, Math.floor(12 / gridsize),
+                            ["pr-status-job"]);
     }
     failed_jobs_html += bs_row(row_content);
   }


### PR DESCRIPTION
This cleans up the look of the HTML output a bit:

![now](https://user-images.githubusercontent.com/675644/45918383-88834700-be86-11e8-9727-6e9f63b16323.png)

vs

![with this change](https://user-images.githubusercontent.com/675644/45918393-9b961700-be86-11e8-983b-37b932fc05aa.png)
